### PR TITLE
Feat/module bulk operations

### DIFF
--- a/src/Commands/AbstractCommand.php
+++ b/src/Commands/AbstractCommand.php
@@ -82,6 +82,34 @@ abstract class AbstractCommand extends Command
         return $this;
     }
 
+    public function optionDryRun(): static {
+        $this->option('--dry-run', 'Report what would be done, without doing it', 'boolval', false);
+        return $this;
+    }
+
+    /**
+     * Whether the command was asked to report its work instead of carrying it out.
+     *
+     * @return bool
+     */
+    public function isDryRun(): bool
+    {
+        return (bool) ($this->values()['dryRun'] ?? false);
+    }
+
+    /**
+     * Report the work a dry run would have carried out.
+     *
+     * @param string $message What the command would have done
+     *
+     * @return void
+     */
+    public function reportDryRun(string $message): void
+    {
+        $this->warn('Dry run, no changes are made.', true);
+        $this->info($message, true);
+    }
+
     public function getOutputFormat($defaultFormat = null) {
         $values = $this->values();
         $supportedFormats = ['json', 'table', 'env', 'csv'];

--- a/src/Commands/Module/AbstractModuleCommand.php
+++ b/src/Commands/Module/AbstractModuleCommand.php
@@ -5,6 +5,8 @@ namespace OSC\Commands\Module;
 use Ahc\Cli\Application as App;
 use Ahc\Cli\Input\Argument;
 use OSC\Commands\AbstractCommand;
+use OSC\Exceptions\WarningException;
+use Throwable;
 
 abstract class AbstractModuleCommand extends AbstractCommand
 {
@@ -18,5 +20,85 @@ abstract class AbstractModuleCommand extends AbstractCommand
         $argument = new Argument($optional ? '[module-id]' : '<module-id>', 'Module id', null, fn($raw) => trim($raw));
         $this->register($argument);
         return $this;
+    }
+
+    /**
+     * Collect the ids of all modules currently in one of the given states.
+     *
+     * Ids are returned instead of Module objects because a module object does not survive a
+     * reload of the module manager; the bulk loop re-fetches each module when its turn comes.
+     *
+     * The result is unordered; use OSC\Helper\ModuleDependencyOrder when the order matters.
+     *
+     * @param string[] $states Omeka module states, see Omeka\Module\Manager::STATE_*
+     *
+     * @return string[] Module ids
+     */
+    protected function collectModuleIdsByState(array $states): array
+    {
+        $moduleIds = [];
+        foreach ($this->getOmekaInstance()->getModuleApi()->getModules() as $module) {
+            if (in_array($module->getState(), $states, true)) {
+                $moduleIds[] = $module->getId();
+            }
+        }
+
+        return $moduleIds;
+    }
+
+    /**
+     * Run an operation over a list of modules, reporting on each one.
+     *
+     * The modules the operation resolved to are listed up front: the command was asked to work
+     * out the set itself, so the caller can not know what it covers until it is shown. Under
+     * --dry-run that listing is all that happens.
+     *
+     * A module that reports a warning does not fail the batch; any other error does, but the
+     * remaining modules are still processed.
+     *
+     * @param string[] $moduleIds The modules to process, in order
+     * @param callable $operation Receives the module id
+     * @param string   $verb      Present tense verb, e.g. "Uninstalling"
+     * @param string   $doneVerb  Past tense verb, e.g. "uninstalled"
+     *
+     * @return bool Whether every module was handled successfully
+     */
+    protected function runBulkOperation(array $moduleIds, callable $operation, string $verb, string $doneVerb): bool
+    {
+        $success = true;
+
+        if ($this->isDryRun()) {
+            $planned = sprintf(
+                '%d module(s) would be %s: %s.',
+                count($moduleIds),
+                $doneVerb,
+                implode(', ', $moduleIds)
+            );
+            $this->reportDryRun($planned);
+            return true;
+        }
+
+        $summary = sprintf(
+            '%s %d module(s): %s.',
+            $verb,
+            count($moduleIds),
+            implode(', ', $moduleIds)
+        );
+        $this->info($summary, true);
+
+        foreach ($moduleIds as $moduleId) {
+            try {
+                $this->info("{$verb} module: {$moduleId}", true);
+                $operation($moduleId);
+                $this->ok("Module '{$moduleId}' {$doneVerb}.", true);
+            } catch (WarningException $e) {
+                $this->warn($e->getMessage(), true);
+            } catch (Throwable $e) {
+                $this->error($e->getMessage(), true);
+                $success = false;
+            }
+        }
+
+        return $success;
     }
 }

--- a/src/Commands/Module/DeleteCommand.php
+++ b/src/Commands/Module/DeleteCommand.php
@@ -4,8 +4,6 @@ namespace OSC\Commands\Module;
 use Exception;
 use InvalidArgumentException;
 use Omeka\Module\Manager as ModuleManager;
-use OSC\Exceptions\WarningException;
-use Throwable;
 
 class DeleteCommand extends AbstractModuleCommand
 {
@@ -17,9 +15,10 @@ class DeleteCommand extends AbstractModuleCommand
         $this->argumentModuleId(true);
         $this->option('-f --force', 'Force module uninstall', 'boolval', false);
         $this->option('--not-installed', 'Delete all uninstalled modules', 'boolval', false);
+        $this->optionDryRun();
     }
 
-    public function execute(?string $moduleId, ?bool $force, ?bool $notInstalled): void
+    public function execute(?string $moduleId, ?bool $force = false, ?bool $notInstalled = false): void
     {
         if(!$moduleId && !$notInstalled) {
             throw new InvalidArgumentException("You must specify a module ID or the --not-installed option.");
@@ -34,10 +33,25 @@ class DeleteCommand extends AbstractModuleCommand
         if ($moduleId) {
             $module = $moduleApi->getModule($moduleId);
 
-            if($module->getState() === ModuleManager::STATE_ACTIVE || $module->getState() === ModuleManager::STATE_NOT_ACTIVE) {
-                if (!$force) {
-                    throw new Exception("The module is currently installed. Use the --force flag to uninstall the module.");
-                }
+            $installed = in_array(
+                $module->getState(),
+                [ModuleManager::STATE_ACTIVE, ModuleManager::STATE_NOT_ACTIVE],
+                true
+            );
+
+            if ($installed && !$force) {
+                throw new Exception("The module is currently installed. Use the --force flag to uninstall the module.");
+            }
+
+            if ($this->isDryRun()) {
+                $planned = $installed
+                    ? "Module '{$moduleId}' would be uninstalled and deleted."
+                    : "Module '{$moduleId}' would be deleted.";
+                $this->reportDryRun($planned);
+                return;
+            }
+
+            if ($installed) {
                 // Uninstall the module
                 $moduleApi->uninstall($module);
                 $this->ok("Module '{$moduleId}' uninstalled.", true);
@@ -48,40 +62,34 @@ class DeleteCommand extends AbstractModuleCommand
         }
 
         if ($notInstalled) {
-            $modulesToDelete = [];
-            $modules = $moduleApi->getModules();
-            foreach ($modules as $module) {
-                if ($module->getState() !== ModuleManager::STATE_NOT_INSTALLED) {
-                    continue;
-                }
-                $modulesToDelete[] = $module->getId();
-            }
+            $modulesToDelete = $this->collectModulesToDelete();
 
             if (!count($modulesToDelete)) {
                 $this->info("No modules to delete.", true);
                 return;
             }
 
-            $errors = false;
-            foreach ($modulesToDelete as $moduleId) {
-                try {
-                    $this->info("Delete module: $moduleId", true);
+            $delete = fn($moduleId) => $moduleApi->delete($moduleApi->getModule($moduleId));
 
-                    $module = $moduleApi->getModule($moduleId);
-                    $moduleApi->delete($module);
+            $success = $this->runBulkOperation($modulesToDelete, $delete, 'Deleting', 'deleted');
 
-                    $this->ok("Module '{$moduleId}' deleted.", true);
-                } catch (WarningException $e) {
-                    $this->warn($e->getMessage(), true);
-                } catch (Throwable $e) {
-                    $this->error($e->getMessage(), true);
-                    $errors = true;
-                }
-            }
-
-            if ($errors) {
+            if (!$success) {
                 $this->error("Some modules could not be deleted due to errors.", true);
             }
         }
+    }
+
+    /**
+     * Collect the modules a bulk delete would affect.
+     *
+     * Order does not matter here: the files removed belong to modules that are not installed,
+     * so nothing depends on them at this point.
+     *
+     * @return string[] Module ids that are not installed
+     */
+    protected function collectModulesToDelete(): array
+    {
+        // only a module that is not installed can have its files removed
+        return $this->collectModuleIdsByState([ModuleManager::STATE_NOT_INSTALLED]);
     }
 }

--- a/src/Commands/Module/DisableCommand.php
+++ b/src/Commands/Module/DisableCommand.php
@@ -1,7 +1,9 @@
 <?php
 namespace OSC\Commands\Module;
 
+use InvalidArgumentException;
 use Omeka\Module\Manager as ModuleManager;
+use OSC\Helper\ModuleDependencyOrder;
 
 class DisableCommand extends AbstractModuleCommand
 {
@@ -10,17 +12,69 @@ class DisableCommand extends AbstractModuleCommand
     public function __construct()
     {
         parent::__construct('module:disable', 'Disable module');
-        $this->argumentModuleId();
+        $this->argumentModuleId(true);
+        $this->option('-a --all', 'Disable all active modules', 'boolval', false);
+        $this->optionDryRun();
     }
 
-    public function execute(?string $moduleId): void
+    public function execute(?string $moduleId, ?bool $all = false): void
     {
-        $module = $this->getOmekaInstance()->getModuleApi()->getModule($moduleId);
-        if ($module->getState() === ModuleManager::STATE_NOT_ACTIVE) {
-            $this->warn("Module '{$moduleId}' is already disabled.", true);
-            return;
+        if (!$moduleId && !$all) {
+            throw new InvalidArgumentException("You must specify a module ID or the --all option.");
         }
-        $this->getOmekaInstance()->getModuleApi()->disable($module);
-        $this->ok("Module '{$moduleId}' disabled.", true);
+
+        if ($moduleId && $all) {
+            throw new InvalidArgumentException("You cannot specify both a module ID and the --all option.");
+        }
+
+        $moduleApi = $this->getOmekaInstance()->getModuleApi();
+
+        if ($moduleId) {
+            $module = $moduleApi->getModule($moduleId);
+            if ($module->getState() === ModuleManager::STATE_NOT_ACTIVE) {
+                $this->warn("Module '{$moduleId}' is already disabled.", true);
+                return;
+            }
+            if ($this->isDryRun()) {
+                $this->reportDryRun("Module '{$moduleId}' would be disabled.");
+                return;
+            }
+
+            $moduleApi->disable($module);
+            $this->ok("Module '{$moduleId}' disabled.", true);
+        }
+
+        if ($all) {
+            $modulesToDisable = $this->collectModulesToDisable();
+
+            if (!count($modulesToDisable)) {
+                $this->info("No modules to disable.", true);
+                return;
+            }
+
+            $success = $this->runBulkOperation(
+                $modulesToDisable,
+                fn($id) => $moduleApi->disable($moduleApi->getModule($id)),
+                'Disabling',
+                'disabled'
+            );
+
+            if (!$success) {
+                $this->error("Some modules could not be disabled due to errors.", true);
+            }
+        }
+    }
+
+    /**
+     * Collect the modules a bulk disable would affect.
+     *
+     * @return string[] Active module ids, dependencies last
+     */
+    protected function collectModulesToDisable(): array
+    {
+        // only an active module can be disabled, dependencies after their dependents
+        return ModuleDependencyOrder::reverseSort(
+            $this->collectModuleIdsByState([ModuleManager::STATE_ACTIVE])
+        );
     }
 }

--- a/src/Commands/Module/EnableCommand.php
+++ b/src/Commands/Module/EnableCommand.php
@@ -1,7 +1,9 @@
 <?php
 namespace OSC\Commands\Module;
 
+use InvalidArgumentException;
 use Omeka\Module\Manager as ModuleManager;
+use OSC\Helper\ModuleDependencyOrder;
 
 class EnableCommand extends AbstractModuleCommand
 {
@@ -10,17 +12,69 @@ class EnableCommand extends AbstractModuleCommand
     public function __construct()
     {
         parent::__construct('module:enable', 'Enable module');
-        $this->argumentModuleId();
+        $this->argumentModuleId(true);
+        $this->option('-a --all', 'Enable all disabled modules', 'boolval', false);
+        $this->optionDryRun();
     }
 
-    public function execute(?string $moduleId): void
+    public function execute(?string $moduleId, ?bool $all = false): void
     {
-        $module = $this->getOmekaInstance()->getModuleApi()->getModule($moduleId);
-        if ($module->getState() === ModuleManager::STATE_ACTIVE) {
-            $this->warn("Module '{$moduleId}' is already enabled.", true);
-            return;
+        if (!$moduleId && !$all) {
+            throw new InvalidArgumentException("You must specify a module ID or the --all option.");
         }
-        $this->getOmekaInstance()->getModuleApi()->enable($module);
-        $this->ok("Module '{$moduleId}' enabled.", true);
+
+        if ($moduleId && $all) {
+            throw new InvalidArgumentException("You cannot specify both a module ID and the --all option.");
+        }
+
+        $moduleApi = $this->getOmekaInstance()->getModuleApi();
+
+        if ($moduleId) {
+            $module = $moduleApi->getModule($moduleId);
+            if ($module->getState() === ModuleManager::STATE_ACTIVE) {
+                $this->warn("Module '{$moduleId}' is already enabled.", true);
+                return;
+            }
+            if ($this->isDryRun()) {
+                $this->reportDryRun("Module '{$moduleId}' would be enabled.");
+                return;
+            }
+
+            $moduleApi->enable($module);
+            $this->ok("Module '{$moduleId}' enabled.", true);
+        }
+
+        if ($all) {
+            $modulesToEnable = $this->collectModulesToEnable();
+
+            if (!count($modulesToEnable)) {
+                $this->info("No modules to enable.", true);
+                return;
+            }
+
+            $success = $this->runBulkOperation(
+                $modulesToEnable,
+                fn($id) => $moduleApi->enable($moduleApi->getModule($id)),
+                'Enabling',
+                'enabled'
+            );
+
+            if (!$success) {
+                $this->error("Some modules could not be enabled due to errors.", true);
+            }
+        }
+    }
+
+    /**
+     * Collect the modules a bulk enable would affect.
+     *
+     * @return string[] Disabled module ids, dependencies first
+     */
+    protected function collectModulesToEnable(): array
+    {
+        // only a disabled module can be enabled, dependencies before their dependents
+        return ModuleDependencyOrder::sort(
+            $this->collectModuleIdsByState([ModuleManager::STATE_NOT_ACTIVE])
+        );
     }
 }

--- a/src/Commands/Module/InstallCommand.php
+++ b/src/Commands/Module/InstallCommand.php
@@ -1,7 +1,9 @@
 <?php
 namespace OSC\Commands\Module;
 
+use InvalidArgumentException;
 use Omeka\Module\Manager as ModuleManager;
+use OSC\Helper\ModuleDependencyOrder;
 
 class InstallCommand extends AbstractModuleCommand
 {
@@ -10,20 +12,70 @@ class InstallCommand extends AbstractModuleCommand
     public function __construct()
     {
         parent::__construct('module:install', 'Install module');
-        $this->argumentModuleId();
+        $this->argumentModuleId(true);
+        $this->option('-a --all', 'Install all downloaded modules that are not installed', 'boolval', false);
+        $this->optionDryRun();
     }
 
-    public function execute(?string $moduleId): void
+    public function execute(?string $moduleId, ?bool $all = false): void
     {
-        $module = $this->getOmekaInstance()->getModuleApi()->getModule($moduleId);
-        if (in_array($module->getState(), [ModuleManager::STATE_ACTIVE, ModuleManager::STATE_NOT_ACTIVE], true)) {
-            $this->warn("Module '{$moduleId}' is already installed.", true);
-            return;
+        if (!$moduleId && !$all) {
+            throw new InvalidArgumentException("You must specify a module ID or the --all option.");
         }
-        // todo: Check module dependencies
 
-        // install
-        $this->getOmekaInstance()->getModuleApi()->install($module);
-        $this->ok("Module '{$moduleId}' installed.", true);
+        if ($moduleId && $all) {
+            throw new InvalidArgumentException("You cannot specify both a module ID and the --all option.");
+        }
+
+        $moduleApi = $this->getOmekaInstance()->getModuleApi();
+
+        if ($moduleId) {
+            $module = $moduleApi->getModule($moduleId);
+            if (in_array($module->getState(), [ModuleManager::STATE_ACTIVE, ModuleManager::STATE_NOT_ACTIVE], true)) {
+                $this->warn("Module '{$moduleId}' is already installed.", true);
+                return;
+            }
+            // todo: Check module dependencies
+            if ($this->isDryRun()) {
+                $this->reportDryRun("Module '{$moduleId}' would be installed.");
+                return;
+            }
+
+            $moduleApi->install($module);
+            $this->ok("Module '{$moduleId}' installed.", true);
+        }
+
+        if ($all) {
+            $modulesToInstall = $this->collectModulesToInstall();
+
+            if (!count($modulesToInstall)) {
+                $this->info("No modules to install.", true);
+                return;
+            }
+
+            $success = $this->runBulkOperation(
+                $modulesToInstall,
+                fn($id) => $moduleApi->install($moduleApi->getModule($id)),
+                'Installing',
+                'installed'
+            );
+
+            if (!$success) {
+                $this->error("Some modules could not be installed due to errors.", true);
+            }
+        }
+    }
+
+    /**
+     * Collect the modules a bulk install would affect.
+     *
+     * @return string[] Module ids that are downloaded but not installed, dependencies first
+     */
+    protected function collectModulesToInstall(): array
+    {
+        // only a module that is not installed can be installed, dependencies before their dependents
+        return ModuleDependencyOrder::sort(
+            $this->collectModuleIdsByState([ModuleManager::STATE_NOT_INSTALLED])
+        );
     }
 }

--- a/src/Commands/Module/UninstallCommand.php
+++ b/src/Commands/Module/UninstallCommand.php
@@ -3,8 +3,7 @@ namespace OSC\Commands\Module;
 
 use InvalidArgumentException;
 use Omeka\Module\Manager as ModuleManager;
-use OSC\Exceptions\WarningException;
-use Throwable;
+use OSC\Helper\ModuleDependencyOrder;
 
 class UninstallCommand extends AbstractModuleCommand
 {
@@ -13,68 +12,110 @@ class UninstallCommand extends AbstractModuleCommand
     public function __construct()
     {
         parent::__construct('module:uninstall', 'Uninstall module');
+        $this->option('-a --all', 'Uninstall all installed modules', 'boolval', false);
         $this->option('--not-active', 'Uninstall all inactive modules', 'boolval', false);
+        $this->optionDryRun();
         $this->argumentModuleId(true);
     }
 
-    public function execute(?string $moduleId, ?bool $notActive): void
+    public function execute(?string $moduleId, ?bool $all = false, ?bool $notActive = false): void
     {
-        if(!$moduleId && !$notActive) {
-            throw new InvalidArgumentException("You must specify a module ID or the --not-active option.");
+        $selectors = count(array_filter([$moduleId, $all, $notActive]));
+
+        if ($selectors === 0) {
+            throw new InvalidArgumentException("You must specify a module ID, the --all option or the --not-active option.");
         }
 
-        if ($moduleId && $notActive) {
-            throw new InvalidArgumentException("You cannot specify both a module ID and the --not-active option.");
+        if ($selectors > 1) {
+            throw new InvalidArgumentException("You can only specify one of a module ID, the --all option or the --not-active option.");
         }
 
         $moduleApi = $this->getOmekaInstance()->getModuleApi();
 
         if ($moduleId) {
-            $module = $this->getOmekaInstance()->getModuleApi()->getModule($moduleId);
+            $module = $moduleApi->getModule($moduleId);
             if ($module->getState() === ModuleManager::STATE_NOT_INSTALLED) {
                 $this->warn("Module '{$moduleId}' is already uninstalled.", true);
                 return;
             }
 
-            $moduleApi->uninstall($module);
-            $this->ok("Module '{$moduleId}' uninstalled.", true);
-        }
-
-        if ($notActive) {
-            $modulesToUninstall = [];
-            $modules = $moduleApi->getModules();
-            foreach ($modules as $module) {
-                if ($module->getState() !== ModuleManager::STATE_NOT_ACTIVE) {
-                    continue;
-                }
-                $modulesToUninstall[] = $module->getId();
-            }
-
-            if (!count($modulesToUninstall)) {
-                $this->info("No modules to uninstall.", true);
+            if ($this->isDryRun()) {
+                $this->reportDryRun("Module '{$moduleId}' would be uninstalled.");
                 return;
             }
 
-            $errors = false;
-            foreach ($modulesToUninstall as $moduleId) {
-                try {
-                    $this->info("Uninstall module: $moduleId", true);
+            $moduleApi->uninstall($module);
+            $this->ok("Module '{$moduleId}' uninstalled.", true);
+            return;
+        }
 
-                    $module = $moduleApi->getModule($moduleId);
-                    $moduleApi->uninstall($module);
-
-                    $this->ok("Module '{$moduleId}' uninstalled.", true);
-                } catch (WarningException $e) {
-                    $this->warn($e->getMessage(), true);
-                } catch (Throwable $e) {
-                    $this->error($e->getMessage(), true);
-                    $errors = true;
-                }
-            }
-
-            if ($errors) {
-                $this->error("Some modules could not be uninstalled due to errors.", true);
+        if ($all) {
+            // a module that still needs an upgrade can not be uninstalled by Omeka S
+            $skipped = $this->collectModulesNeedingUpgrade();
+            if ($skipped) {
+                $message = sprintf(
+                    'Skipping %d module(s) that need an upgrade first: %s.',
+                    count($skipped),
+                    implode(', ', $skipped)
+                );
+                $this->warn($message, true);
             }
         }
+
+        $modulesToUninstall = $this->collectModulesToUninstall((bool) $all, (bool) $notActive);
+
+        if (!count($modulesToUninstall)) {
+            $this->info("No modules to uninstall.", true);
+            return;
+        }
+
+        $success = $this->runBulkOperation(
+            $modulesToUninstall,
+            fn($id) => $moduleApi->uninstall($moduleApi->getModule($id)),
+            'Uninstalling',
+            'uninstalled'
+        );
+
+        if (!$success) {
+            $this->error("Some modules could not be uninstalled due to errors.", true);
+        }
+    }
+
+    /**
+     * Collect the modules a bulk uninstall would affect.
+     *
+     * Each selector names the states it acts on, so that neither option depends on the other
+     * being unset. Without a selector nothing is selected; execute() reports that as an error.
+     *
+     * @param bool $all       Uninstall every installed module
+     * @param bool $notActive Uninstall the inactive modules only
+     *
+     * @return string[] Module ids, dependencies last
+     */
+    protected function collectModulesToUninstall(bool $all, bool $notActive): array
+    {
+        // only an installed module, active or not, can be uninstalled
+        if ($all) {
+            $states = [ModuleManager::STATE_ACTIVE, ModuleManager::STATE_NOT_ACTIVE];
+        } elseif ($notActive) {
+            $states = [ModuleManager::STATE_NOT_ACTIVE];
+        } else {
+            return [];
+        }
+
+        // dependencies are uninstalled after the modules that rely on them
+        return ModuleDependencyOrder::reverseSort($this->collectModuleIdsByState($states));
+    }
+
+    /**
+     * Collect the installed modules that an upgrade has to run on first.
+     *
+     * These can not be uninstalled by Omeka S yet, so a bulk uninstall reports them as skipped.
+     *
+     * @return string[] Module ids awaiting an upgrade
+     */
+    protected function collectModulesNeedingUpgrade(): array
+    {
+        return $this->collectModuleIdsByState([ModuleManager::STATE_NEEDS_UPGRADE]);
     }
 }

--- a/src/Commands/Module/UpdateCommand.php
+++ b/src/Commands/Module/UpdateCommand.php
@@ -14,12 +14,13 @@ class UpdateCommand extends AbstractModuleCommand
     public function __construct()
     {
         parent::__construct('module:update', 'Update module');
-        $this->argument('[module-id]', 'Module name or ID to update', null);
+        $this->argumentModuleId(true);
         $this->option('-a --all', 'Update all modules', null, false);
         $this->option('-u --upgrade', 'Upgrade module after download', 'boolval', false);
+        $this->optionDryRun();
     }
 
-    public function execute(?string $moduleId, ?bool $upgrade, ?bool $all): void
+    public function execute(?string $moduleId, ?bool $upgrade = false, ?bool $all = false): void
     {
         if ($moduleId && $all) {
             throw new InvalidArgumentException("You cannot specify both a module ID and the --all option.");
@@ -34,6 +35,14 @@ class UpdateCommand extends AbstractModuleCommand
 
             // check if module exists (result is not used)
             $module = $this->getOmekaInstance()->getModuleApi()->getModule($moduleUri->getId());
+
+            if ($this->isDryRun()) {
+                $planned = $upgrade
+                    ? "Module '{$module->getId()}' would be updated and upgraded."
+                    : "Module '{$module->getId()}' would be updated.";
+                $this->reportDryRun($planned);
+                return;
+            }
 
             // download the module
             /** @var DownloadCommand $command */
@@ -51,36 +60,28 @@ class UpdateCommand extends AbstractModuleCommand
         }
 
         if ($all) {
-            $modulesToInstall = [];
-            $modules = $this->getOmekaInstance()->getModuleApi()->getModules();
-            foreach ($modules as $module) {
-                $moduleInfo = $this->formatModuleStatus($module);
-                if (!$moduleInfo['updateAvailable']) {
-                    continue;
-                }
-                $modulesToInstall[] = $moduleInfo['id'];
-            }
+            $modulesToUpdate = $this->collectModulesToUpdate();
 
-            if (!count($modulesToInstall)) {
+            if (!count($modulesToUpdate)) {
                 $this->info("No modules to update.", true);
                 return;
             }
 
             // download modules
-            $hasErrors = false;
-            foreach ($modulesToInstall as $moduleId) {
-                try {
-                    $this->info("Updating module: $moduleId", true);
+            $download = function ($moduleId) {
+                /** @var DownloadCommand $command */
+                $command = $this->app()->commands()['module:download'] ?? null;
+                $command && $command->execute($moduleId, force: true);
+            };
 
-                    /** @var DownloadCommand $command */
-                    $command = $this->app()->commands()['module:download'] ?? null;
-                    $command && $command->execute($moduleId, force: true);
-                } catch (WarningException $e) {
-                    $this->warn($e->getMessage(), true);
-                } catch (Throwable $e) {
-                    $hasErrors = true;
-                    $this->error($e->getMessage(), true);
+            $hasErrors = !$this->runBulkOperation($modulesToUpdate, $download, 'Updating', 'updated');
+
+            if ($this->isDryRun()) {
+                // runBulkOperation reported the modules; the upgrade would follow in a new process
+                if ($upgrade) {
+                    $this->info('They would then be upgraded.', true);
                 }
+                return;
             }
 
             // upgrade modules if requested
@@ -105,5 +106,29 @@ class UpdateCommand extends AbstractModuleCommand
 
             $this->info("All modules updated.", true);
         }
+    }
+
+    /**
+     * Collect the modules a bulk update would affect.
+     *
+     * Unlike the other bulk commands this does not select on a module state: a module can only be
+     * updated when the repository offers a newer version, which formatModuleStatus() resolves per
+     * module through the repository manager. That is a network lookup, which is why the other
+     * commands filter on state instead.
+     *
+     * @return string[] Module ids with a newer version available
+     */
+    protected function collectModulesToUpdate(): array
+    {
+        $moduleIds = [];
+        foreach ($this->getOmekaInstance()->getModuleApi()->getModules() as $module) {
+            $moduleInfo = $this->formatModuleStatus($module);
+            if (!$moduleInfo['updateAvailable']) {
+                continue;
+            }
+            $moduleIds[] = $moduleInfo['id'];
+        }
+
+        return $moduleIds;
     }
 }

--- a/src/Commands/Module/UpgradeCommand.php
+++ b/src/Commands/Module/UpgradeCommand.php
@@ -2,21 +2,19 @@
 namespace OSC\Commands\Module;
 
 use InvalidArgumentException;
-use OSC\Exceptions\WarningException;
-use Throwable;
 use Omeka\Module\Manager as ModuleManager;
+use OSC\Helper\ModuleDependencyOrder;
 
 class UpgradeCommand extends AbstractModuleCommand
 {
     use FormattersTrait;
 
-    protected bool $argumentModuleId = true;
-
     public function __construct()
     {
         parent::__construct('module:upgrade', 'Upgrade module');
-        $this->argument('[module-id]', 'Module name or ID to upgrade', null);
+        $this->argumentModuleId(true);
         $this->option('-a --all', 'Upgrade all modules', null, false);
+        $this->optionDryRun();
     }
 
     public function execute(?string $moduleId, bool $all = false): void
@@ -38,54 +36,48 @@ class UpgradeCommand extends AbstractModuleCommand
                 $this->warn("Module '{$moduleId}' does not need upgrade.", true);
                 return;
             }
+            if ($this->isDryRun()) {
+                $this->reportDryRun("Module '{$moduleId}' would be upgraded.");
+                return;
+            }
+
             $moduleApi->upgrade($module);
             $this->ok("Module '{$moduleId}' upgraded.", true);
         }
 
         // Upgrade all modules that need upgrade
         if ($all) {
-            $modulesToUpgrade = [];
-            $modules = $moduleApi->getModules();
-            foreach ($modules as $module) {
-                if ($module->getState() !== ModuleManager::STATE_NEEDS_UPGRADE) {
-                    continue;
-                }
-                $modulesToUpgrade[] = $module->getId();
-            }
+            $modulesToUpgrade = $this->collectModulesToUpgrade();
 
             if (!count($modulesToUpgrade)) {
                 $this->info("No modules to upgrade.", true);
                 return;
             }
 
-            // Schedule known modules for upgrade based on priority
-            $upgradePriority = ['Common' => 1, 'Log' => 10, 'IiifServer' => 20];
-            $getPriority = fn($id) => $upgradePriority[$id] ?? 1000;
-            usort($modulesToUpgrade, fn($a, $b) => $getPriority($a) <=> $getPriority($b));
+            $upgrade = function ($moduleId) use ($moduleApi) {
+                $moduleApi->upgrade($moduleApi->getModule($moduleId));
+                // reload module manager
+                $moduleApi->reload();
+            };
 
-            $errors = false;
-            foreach ($modulesToUpgrade as $moduleId) {
-                try {
-                    $this->info("Upgrading module: $moduleId", true);
+            $success = $this->runBulkOperation($modulesToUpgrade, $upgrade, 'Upgrading', 'upgraded');
 
-                    $module = $moduleApi->getModule($moduleId);
-                    $moduleApi->upgrade($module);
-
-                    // reload module manager
-                    $moduleApi->reload();
-
-                    $this->ok("Module '{$moduleId}' upgraded.", true);
-                } catch (WarningException $e) {
-                    $this->warn($e->getMessage(), true);
-                } catch (Throwable $e) {
-                    $this->error($e->getMessage(), true);
-                    $errors = true;
-                }
-            }
-
-            if ($errors) {
+            if (!$success) {
                 $this->error("Some modules could not be upgraded due to errors.", true);
             }
         }
+    }
+
+    /**
+     * Collect the modules a bulk upgrade would affect.
+     *
+     * @return string[] Module ids awaiting an upgrade, dependencies first
+     */
+    protected function collectModulesToUpgrade(): array
+    {
+        // dependencies are upgraded before the modules that rely on them
+        return ModuleDependencyOrder::sort(
+            $this->collectModuleIdsByState([ModuleManager::STATE_NEEDS_UPGRADE])
+        );
     }
 }

--- a/src/Helper/ModuleDependencyOrder.php
+++ b/src/Helper/ModuleDependencyOrder.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace OSC\Helper;
+
+/**
+ * Orders modules so that a module is never left without a dependency it needs.
+ *
+ * Operations that build modules up (enable, upgrade) handle dependencies first, operations that
+ * tear them down (disable, uninstall) handle them last.
+ *
+ * The order is maintained by hand: Omeka S modules do not declare their dependencies in
+ * config/module.ini, so there is nothing on disc to derive it from.
+ */
+class ModuleDependencyOrder
+{
+    /**
+     * Modules that other modules depend on, most depended upon first.
+     */
+    private const ORDER = [
+        'Common' => 1,
+        'Log' => 10,
+        'IiifServer' => 20,
+    ];
+
+    /**
+     * Rank given to modules that nothing is known to depend on.
+     */
+    private const UNRANKED = 1000;
+
+    /**
+     * Order modules with their dependencies first.
+     *
+     * @param string[] $moduleIds Module ids in any order
+     *
+     * @return string[] The same ids, dependencies first
+     */
+    public static function sort(array $moduleIds): array
+    {
+        usort($moduleIds, fn($a, $b) => self::rank($a) <=> self::rank($b));
+
+        return $moduleIds;
+    }
+
+    /**
+     * Order modules with their dependencies last.
+     *
+     * @param string[] $moduleIds Module ids in any order
+     *
+     * @return string[] The same ids, dependencies last
+     */
+    public static function reverseSort(array $moduleIds): array
+    {
+        usort($moduleIds, fn($a, $b) => self::rank($b) <=> self::rank($a));
+
+        return $moduleIds;
+    }
+
+    /**
+     * How early a module has to be handled; the lower the rank, the more depends on it.
+     *
+     * @param string $moduleId Module id to look up
+     *
+     * @return int The rank, or UNRANKED when nothing is known to depend on the module
+     */
+    private static function rank(string $moduleId): int
+    {
+        return self::ORDER[$moduleId] ?? self::UNRANKED;
+    }
+}

--- a/src/Repository/Module/OmekaDotOrg.php
+++ b/src/Repository/Module/OmekaDotOrg.php
@@ -39,13 +39,21 @@ class OmekaDotOrg extends AbstractRepository
             return $output;
         }
 
+        // Check data structure
         $firstItem = current($data);
-        if (!isset($firstItem['dirname'], $firstItem['latest_version'], $firstItem['versions'], $firstItem['owner'])) {
-            throw new \UnexpectedValueException("Invalid data structure from " . self::API_ENDPOINT);
+        foreach (['dirname', 'latest_version', 'versions', 'owner'] as $key) {
+            if (!array_key_exists($key, $firstItem)) {
+                throw new \UnexpectedValueException("Invalid data structure from " . self::API_ENDPOINT);
+            }
         }
 
         // Create the modules array
         foreach ($data as $module) {
+            // an add-on without a published release can not be used
+            if (empty($module['latest_version']) || !isset($module['versions'][$module['latest_version']])) {
+                continue;
+            }
+
             $versions = [];
             foreach (($module['versions'] ?? []) as $version => $versionData) {
                 $versions[$version] = new ModuleVersion(

--- a/src/Repository/Theme/OmekaDotOrg.php
+++ b/src/Repository/Theme/OmekaDotOrg.php
@@ -33,8 +33,22 @@ class OmekaDotOrg extends AbstractRepository
         // Get the JSON data from the Omeka.org theme list
         $data = ResourceFetcher::fetchJson(self::API_ENDPOINT) ?? [];
 
+        // Check data structure
+        $firstItem = current($data);
+        foreach (['dirname', 'latest_version', 'versions', 'owner'] as $key) {
+            if (!array_key_exists($key, $firstItem)) {
+                throw new \UnexpectedValueException("Invalid data structure from " . self::API_ENDPOINT);
+            }
+        }
+
+
         // Create the modules array
         foreach ($data as $item) {
+            // an add-on without a published release can not be used
+            if (empty($item['latest_version']) || !isset($item['versions'][$item['latest_version']])) {
+                continue;
+            }
+
             $versions = [];
             foreach ($item['versions'] as $version => $versionInfo) {
                 $versions[$version] = new ThemeVersion(

--- a/tests/Helper/FileUtilsTest.php
+++ b/tests/Helper/FileUtilsTest.php
@@ -1,0 +1,88 @@
+<?php
+namespace Tests\Helper;
+
+use InvalidArgumentException;
+use OSC\Helper\Path;
+use PHPUnit\Framework\TestCase;
+
+class FileUtilsTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/file_utils_test_' . uniqid();
+        mkdir($this->tempDir, 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        if (is_dir($this->tempDir)) {
+            $this->removeDir($this->tempDir);
+        }
+    }
+
+    private function removeDir(string $path): void
+    {
+        foreach (new \DirectoryIterator($path) as $item) {
+            if ($item->isDot()) continue;
+            $item->isDir() ? $this->removeDir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($path);
+    }
+
+    public function testFindSubpathDirectMatch(): void
+    {
+        // target is directly inside baseFolder
+        mkdir($this->tempDir . '/target');
+
+        $result = Path::findSubpath($this->tempDir, 'target');
+        $this->assertEquals(realpath($this->tempDir), $result);
+    }
+
+    public function testFindSubpathNestedOneLevel(): void
+    {
+        // target is one level deep
+        mkdir($this->tempDir . '/level1');
+        mkdir($this->tempDir . '/level1/target');
+
+        $result = Path::findSubpath($this->tempDir, 'target');
+        $this->assertEquals(realpath($this->tempDir . '/level1'), $result);
+    }
+
+    public function testFindSubpathNestedTwoLevels(): void
+    {
+        // target is two levels deep — would fail without RecursiveIteratorIterator
+        mkdir($this->tempDir . '/level1/level2', 0700, true);
+        mkdir($this->tempDir . '/level1/level2/target');
+
+        $result = Path::findSubpath($this->tempDir, 'target');
+        $this->assertEquals(realpath($this->tempDir . '/level1/level2'), $result);
+    }
+
+    public function testFindSubpathFileTarget(): void
+    {
+        // target can also be a file
+        mkdir($this->tempDir . '/level1/level2', 0700, true);
+        file_put_contents($this->tempDir . '/level1/level2/config.json', '{}');
+
+        $result = Path::findSubpath($this->tempDir, 'config.json');
+        $this->assertEquals(realpath($this->tempDir . '/level1/level2'), $result);
+    }
+
+    public function testFindSubpathReturnsNullWhenNotFound(): void
+    {
+        mkdir($this->tempDir . '/level1');
+
+        $result = Path::findSubpath($this->tempDir, 'nonexistent');
+        $this->assertNull($result);
+    }
+
+    public function testFindSubpathThrowsOnInvalidBaseFolder(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        Path::findSubpath('/nonexistent/path', 'target');
+    }
+}

--- a/tests/Helper/ModuleDependencyOrderTest.php
+++ b/tests/Helper/ModuleDependencyOrderTest.php
@@ -1,0 +1,71 @@
+<?php
+namespace Tests\Helper;
+
+use OSC\Helper\ModuleDependencyOrder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ModuleDependencyOrder::class)]
+class ModuleDependencyOrderTest extends TestCase
+{
+    public function testSortPutsDependenciesFirst(): void
+    {
+        $this->assertEquals(
+            ['Common', 'Log', 'IiifServer'],
+            ModuleDependencyOrder::sort(['IiifServer', 'Log', 'Common'])
+        );
+    }
+
+    public function testReverseSortPutsDependenciesLast(): void
+    {
+        $this->assertEquals(
+            ['IiifServer', 'Log', 'Common'],
+            ModuleDependencyOrder::reverseSort(['Common', 'Log', 'IiifServer'])
+        );
+    }
+
+    public function testUnknownModulesComeAfterKnownOnes(): void
+    {
+        $sorted = ModuleDependencyOrder::sort(['ValueSuggest', 'Common', 'BulkEdit', 'Log']);
+
+        $this->assertEquals(['Common', 'Log', 'ValueSuggest', 'BulkEdit'], $sorted);
+    }
+
+    public function testUnknownModulesComeFirstWhenReversed(): void
+    {
+        $sorted = ModuleDependencyOrder::reverseSort(['ValueSuggest', 'Common', 'BulkEdit', 'Log']);
+
+        $this->assertEquals(['ValueSuggest', 'BulkEdit', 'Log', 'Common'], $sorted);
+    }
+
+    public function testUnknownModulesKeepTheirRelativeOrder(): void
+    {
+        $modules = ['ValueSuggest', 'BulkEdit', 'EasyAdmin'];
+
+        // sorting is stable, so a list without known dependencies is left as it is
+        $this->assertEquals($modules, ModuleDependencyOrder::sort($modules));
+        $this->assertEquals($modules, ModuleDependencyOrder::reverseSort($modules));
+    }
+
+    public function testReverseSortIsTheMirrorOfSort(): void
+    {
+        $modules = ['IiifServer', 'ValueSuggest', 'Common', 'BulkEdit', 'Log'];
+
+        $this->assertEquals(
+            ModuleDependencyOrder::sort($modules),
+            array_reverse(ModuleDependencyOrder::reverseSort(array_reverse($modules)))
+        );
+    }
+
+    public function testEmptyList(): void
+    {
+        $this->assertEquals([], ModuleDependencyOrder::sort([]));
+        $this->assertEquals([], ModuleDependencyOrder::reverseSort([]));
+    }
+
+    public function testSingleModule(): void
+    {
+        $this->assertEquals(['Common'], ModuleDependencyOrder::sort(['Common']));
+        $this->assertEquals(['BulkEdit'], ModuleDependencyOrder::reverseSort(['BulkEdit']));
+    }
+}

--- a/tests/Helper/ResourceFetcherTest.php
+++ b/tests/Helper/ResourceFetcherTest.php
@@ -1,0 +1,116 @@
+<?php
+namespace Tests\Helper;
+
+use Ahc\Cli\Exception\InvalidArgumentException;
+use Exception;
+use OSC\Helper\ResourceFetcher;
+use PHPUnit\Framework\TestCase;
+
+class ResourceFetcherTest extends TestCase
+{
+    private string $testFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create a temporary test file
+        $this->testFile = sys_get_temp_dir() . '/test_resource_fetcher_' . uniqid() . '.txt';
+        file_put_contents($this->testFile, 'Test content');
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        // Clean up test file
+        if (file_exists($this->testFile)) {
+            unlink($this->testFile);
+        }
+    }
+
+    public function testDetectTypeFile(): void
+    {
+        $this->assertEquals('file', ResourceFetcher::detectType('/path/to/file.txt'));
+        $this->assertEquals('file', ResourceFetcher::detectType('relative/path/file.txt'));
+    }
+
+    public function testDetectTypeUrl(): void
+    {
+        $this->assertEquals('url', ResourceFetcher::detectType('https://example.org/file.txt'));
+        $this->assertEquals('url', ResourceFetcher::detectType('http://example.org/file.txt'));
+    }
+
+    public function testIsFile(): void
+    {
+        $this->assertTrue(ResourceFetcher::isFile('/path/to/file.txt'));
+        $this->assertFalse(ResourceFetcher::isFile('https://example.org/file.txt'));
+    }
+
+    public function testIsUrl(): void
+    {
+        $this->assertTrue(ResourceFetcher::isUrl('https://example.org/file.txt'));
+        $this->assertFalse(ResourceFetcher::isUrl('/path/to/file.txt'));
+    }
+
+    public function testFetchFromFile(): void
+    {
+        $content = ResourceFetcher::fetch($this->testFile);
+        $this->assertEquals('Test content', $content);
+    }
+
+    public function testFetchFromNonExistentFile(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('File not found');
+
+        ResourceFetcher::fetch('/non/existent/file.txt');
+    }
+
+    public function testValidateExistingFile(): void
+    {
+        $this->assertTrue(ResourceFetcher::validate($this->testFile));
+    }
+
+    public function testValidateNonExistentFile(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('File not found');
+
+        ResourceFetcher::validate('/non/existent/file.txt');
+    }
+
+    public function testValidateUrl(): void
+    {
+        $this->assertTrue(ResourceFetcher::validate('https://example.org/file.txt'));
+    }
+
+    public function testValidateInvalidUrl(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid URL');
+
+        ResourceFetcher::validate('not-a-valid-url');
+    }
+
+    public function testFetchFromUnreachableUrlThrowsCatchableException(): void
+    {
+        // the message depends on the transport (cURL or http stream wrapper)
+        $this->expectException(Exception::class);
+
+        // Must throw a plain exception, without emitting a PHP warning
+        ResourceFetcher::fetch('http://127.0.0.1:1/nope');
+    }
+
+    public function testFetchWithStreamWrapperFromUnreachableUrlThrowsCatchableException(): void
+    {
+        $fetch = new \ReflectionMethod(ResourceFetcher::class, 'fetchWithStreamWrapper');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Failed to fetch URL: http://127.0.0.1:1/nope');
+
+        // Must throw a plain exception, without emitting a PHP warning
+        $fetch->invoke(null, 'http://127.0.0.1:1/nope');
+    }
+}
+

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,6 @@
+<?php
+
+// Include the Composer autoloader
+require_once __DIR__ . '/../vendor/autoload.php';
+
+// Set up any global test configuration here if needed

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -188,15 +188,15 @@ section "Core"
 assert_output_is "core:version shows version" "4.1.1"  $CLI core:version
 assert_output_contains "core:status is 'installed'" "installed"   $CLI core:status
 assert_fail "core:upgrade to nonexistent version fails" $CLI core:upgrade 9.9.9
-assert_success "core:update to 4.2.0" $CLI core:update 4.2.0
+assert_success "core:update to 4.2.1" $CLI core:update 4.2.1
 assert_output_contains "core:status is 'needs_migration'" "needs_migration"   $CLI core:status
 assert_success "core:migrate" $CLI core:migrate
 
 cd /var/www || exit
-assert_output_is "core:version from cwd /var/www with relative base path ./omeka-s" "4.2.0"  $CLI core:version --base-path ./omeka-s
+assert_output_is "core:version from cwd /var/www with relative base path ./omeka-s" "4.2.1"  $CLI core:version --base-path ./omeka-s
 
 cd /var/www/omeka-s/application/src || exit
-assert_output_is "core:version from cwd /var/www/omeka-s/application/src" "4.2.0" $CLI core:version
+assert_output_is "core:version from cwd /var/www/omeka-s/application/src" "4.2.1" $CLI core:version
 
 cd /var/www/omeka-s
 
@@ -206,6 +206,15 @@ section "Modules"
 
 # get module:list output in json and test it has zero modules
 assert_output_is "module:list lists zero modules" "0"   bash -c "$CLI module:list --json | jq '. | length'"
+
+# repositories and search (read-only, no state involved)
+assert_output_contains "module:repositories lists omeka.org" "omeka.org"   $CLI module:repositories
+assert_output_is "module:repositories --json lists two repositories" "2"   bash -c "$CLI module:repositories --json | jq '. | length'"
+assert_success "module:search common"   $CLI module:search common
+assert_success "module:search common --json returns results"   bash -c "$CLI module:search common --json | jq -e '. | length > 0'"
+assert_success "module:search --repository omeka.org"   $CLI module:search advanced --repository omeka.org
+assert_success "module:search --unregistered (modules not on omeka.org)"   bash -c "$CLI module:search --unregistered --json | jq -e '. | length > 0'"
+assert_success "module:search --refresh (re-fetch repository data)"   $CLI module:search common --refresh
 assert_success "module:download common (using repository)"    $CLI module:download common
 assert_success "module:download common version 3.4.82 (force download)"    $CLI module:download common:3.4.82 --force
 assert_output_contains "module:status common is 'not_installed'" "not_installed"   $CLI module:status common
@@ -251,6 +260,90 @@ assert_success    "module:uninstall ValueSuggest"   $CLI module:uninstall ValueS
 
 assert_success "module:delete --not-installed"   $CLI module:delete --not-installed
 assert_output_is "verify 0 modules are not installed" "0"   bash -c "$CLI module:list --not-installed --json | jq '. | length'"
+
+# ── module option guards ─────────────────────────────────────────────────────
+# every bulk command needs exactly one selector: a module id, or a bulk flag
+
+assert_fail "module:enable without module id or --all fails"                  $CLI module:enable
+assert_fail "module:install without module id or --all fails"                 $CLI module:install
+assert_fail "module:disable with both module id and --all fails"              $CLI module:disable common --all
+assert_fail "module:upgrade with both module id and --all fails"              $CLI module:upgrade common --all
+assert_fail "module:delete with both module id and --not-installed fails"     $CLI module:delete common --not-installed
+assert_fail "module:uninstall with both --all and --not-active fails"         $CLI module:uninstall --all --not-active
+
+# ── dry runs ─────────────────────────────────────────────────────────────────
+# a dry run must report the work and change nothing at all
+# state at this point: common and log, both active
+
+assert_output_contains "module:disable --all --dry-run reports two modules" "2 module(s) would be disabled"   $CLI module:disable --all --dry-run
+assert_output_is "dry run disabled nothing" "0"   bash -c "$CLI module:list --not-active --json | jq '. | length'"
+
+assert_output_contains "module:uninstall --all --dry-run reports two modules" "2 module(s) would be uninstalled"   $CLI module:uninstall --all --dry-run
+assert_output_is "dry run uninstalled nothing" "0"   bash -c "$CLI module:list --not-installed --json | jq '. | length'"
+
+assert_output_contains "module:disable common --dry-run reports one module" "would be disabled"   $CLI module:disable common --dry-run
+assert_output_is "dry run left common active" "active"   bash -c "$CLI module:status common --json | jq -r '.[0].state'"
+
+assert_output_contains "module:enable --all --dry-run with nothing to do" "No modules to enable."   $CLI module:enable --all --dry-run
+
+# ── bulk enable and disable ──────────────────────────────────────────────────
+
+assert_success "module:disable --all"   $CLI module:disable --all
+assert_output_is "all modules are inactive" "2"   bash -c "$CLI module:list --not-active --json | jq '. | length'"
+assert_success "module:enable --all"   $CLI module:enable --all
+assert_output_is "no modules are inactive" "0"   bash -c "$CLI module:list --not-active --json | jq '. | length'"
+assert_output_is "both modules are active" "2"   bash -c "$CLI module:list --active --json | jq '. | length'"
+
+# ── bulk install ─────────────────────────────────────────────────────────────
+
+assert_success "module:download customvocab (without installing)"   $CLI module:download customvocab
+assert_success "module:download numericdatatypes (without installing)"   $CLI module:download numericdatatypes
+assert_output_is "two modules are downloaded but not installed" "2"   bash -c "$CLI module:list --not-installed --json | jq '. | length'"
+
+assert_output_contains "module:install --all --dry-run reports two modules" "2 module(s) would be installed"   $CLI module:install --all --dry-run
+assert_output_is "dry run installed nothing" "2"   bash -c "$CLI module:list --not-installed --json | jq '. | length'"
+
+assert_success "module:install --all"   $CLI module:install --all
+assert_output_is "no modules are left uninstalled" "0"   bash -c "$CLI module:list --not-installed --json | jq '. | length'"
+
+# ── bulk update and upgrade ──────────────────────────────────────────────────
+
+assert_success "module:download AdvancedResourceTemplate:3.4.51 --install (outdated fixture)"   $CLI module:download advancedresourcetemplate:3.4.51 --install --force
+assert_output_is "one module is outdated" "1"   bash -c "$CLI module:list --outdated --json | jq '. | length'"
+
+assert_output_contains "module:update --all --dry-run reports one module" "1 module(s) would be updated"   $CLI module:update --all --dry-run
+assert_output_is "dry run updated nothing" "1"   bash -c "$CLI module:list --outdated --json | jq '. | length'"
+
+assert_success "module:update --all (without --upgrade)"   $CLI module:update --all
+assert_output_is "the updated module needs an upgrade" "1"   bash -c "$CLI module:list --needs-upgrade --json | jq '. | length'"
+
+assert_output_contains "module:upgrade --all --dry-run reports one module" "1 module(s) would be upgraded"   $CLI module:upgrade --all --dry-run
+assert_output_is "dry run upgraded nothing" "1"   bash -c "$CLI module:list --needs-upgrade --json | jq '. | length'"
+
+assert_success "module:upgrade --all"   $CLI module:upgrade --all
+assert_output_is "no modules need an upgrade" "0"   bash -c "$CLI module:list --needs-upgrade --json | jq '. | length'"
+
+# ── output modes ─────────────────────────────────────────────────────────────
+
+assert_output_contains "module:list --csv has a csv header" "id,name,state"   $CLI module:list --csv
+assert_output_contains "module:list --extended shows the module path" "Path"   $CLI module:list --extended
+assert_output_is "module:download --quiet prints nothing" ""   $CLI module:download common --force --quiet
+# the backup is written to $HOME/.omeka-s-cli/backups/modules on the machine running the CLI
+assert_success "module:download --backup keeps the previous version"   $CLI module:download common --force --backup
+
+# ── bulk uninstall and delete, restoring the fixture for later sections ──────
+
+assert_success "module:uninstall --all"   $CLI module:uninstall --all
+assert_output_is "no modules are installed" "0"   bash -c "$CLI module:list --active --json | jq '. | length'"
+
+assert_output_contains "module:delete --not-installed --dry-run reports the modules" "module(s) would be deleted"   $CLI module:delete --not-installed --dry-run
+assert_success "module:delete --not-installed"   $CLI module:delete --not-installed
+assert_output_is "no modules remain" "0"   bash -c "$CLI module:list --json | jq '. | length'"
+
+# later sections need common and log installed and active
+assert_success "reinstall common"   $CLI module:download common --install
+assert_success "reinstall log"   $CLI module:download log --install
+assert_output_is "common and log are active again" "2"   bash -c "$CLI module:list --active --json | jq '. | length'"
 
 # ── themes ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
This pull request adds significant improvements to the module management CLI commands, introducing bulk operations and a dry-run mode for safer and more flexible workflows. It refactors the commands for enabling, disabling, installing, uninstalling, and deleting modules to support batch processing, dependency-aware ordering, and reporting. Additionally, it introduces consistent error handling and user feedback.

**Bulk Operations and Dry-Run Support:**

* Added a `--all` option and bulk-processing logic to `InstallCommand`, `EnableCommand`, and `DisableCommand`, allowing operations on all applicable modules in a single command. The order of processing respects module dependencies using `ModuleDependencyOrder`. [[1]](diffhunk://#diff-f6b8b3b083fa1638b3bd3e6f1cce14f066024bcf79165c94cc6d96af207c921fL13-R80) [[2]](diffhunk://#diff-bafea1cbe1bba5765cbb94e867350086a81b7068254c616c3398c675703a1799L13-R79) [[3]](diffhunk://#diff-10399f4b574fdcba002f917ca44d680638ba8d035a3f6bb7e128c9125909b4b2L13-R79)
* Added a `--dry-run` option to all module commands, enabling users to preview actions without making changes. The new `optionDryRun`, `isDryRun`, and `reportDryRun` methods in `AbstractCommand` provide the underlying support. [[1]](diffhunk://#diff-f4c3dcedafc674e3c2310cb039fe2640501c14a2d8684abd642c3a308f353c17R85-R112) [[2]](diffhunk://#diff-f6b8b3b083fa1638b3bd3e6f1cce14f066024bcf79165c94cc6d96af207c921fL13-R80) [[3]](diffhunk://#diff-bafea1cbe1bba5765cbb94e867350086a81b7068254c616c3398c675703a1799L13-R79) [[4]](diffhunk://#diff-10399f4b574fdcba002f917ca44d680638ba8d035a3f6bb7e128c9125909b4b2L13-R79) [[5]](diffhunk://#diff-932d44ad24c6f1a73d97ac9ba3addef178607b9aa44f021e1914cb5af05f8774R18-R21)